### PR TITLE
Provide a consumable channel with custom defined execution stats

### DIFF
--- a/crontab.go
+++ b/crontab.go
@@ -11,10 +11,20 @@ import (
 	"time"
 )
 
+// StatsFunc func representing custom execution statistics
+type StatsFunc func() interface{}
+
+// ExecStats struct representing a standardized wrapper for execution statistics
+type ExecStats struct {
+	JobType string
+	Stats   StatsFunc
+}
+
 // Crontab struct representing cron table
 type Crontab struct {
-	ticker *time.Ticker
-	jobs   []job
+	ticker    *time.Ticker
+	jobs      []job
+	statsChan chan ExecStats
 }
 
 // job in cron table
@@ -46,7 +56,8 @@ func New() *Crontab {
 // new creates new crontab, arg provided for testing purpose
 func new(t time.Duration) *Crontab {
 	c := &Crontab{
-		ticker: time.NewTicker(t),
+		ticker:    time.NewTicker(t),
+		statsChan: make(chan ExecStats),
 	}
 
 	go func() {
@@ -56,6 +67,11 @@ func new(t time.Duration) *Crontab {
 	}()
 
 	return c
+}
+
+// StatsChan returns the channel to consume execution statistics
+func (c *Crontab) StatsChan() chan ExecStats {
+	return c.statsChan
 }
 
 // AddJob to cron table


### PR DESCRIPTION
Many thanks for this library, the way the crontab syntax is parsed is very interesting. 

Sometimes I find useful to publish some aggregated execution statistics of the scheduled function. I hope this could be useful to someone else as well.

Also, it looks like a schedule like this `"* * * * *"` does not start at the beginning of the minute, but just one minute after the execution of the whole program. I am not sure if this is an issue or the expected behavior?

