### PR TITLE
Add use of subtypes in function args

### DIFF
--- a/crontab.go
+++ b/crontab.go
@@ -86,8 +86,9 @@ func (c *Crontab) AddJob(schedule string, fn interface{}, args ...interface{}) e
 		a := args[i]
 		t1 := fnType.In(i)
 		t2 := reflect.TypeOf(a)
-		if t1 != t2 {
-			return fmt.Errorf("Param with index %d shold be `%s` not `%s`", i, t1, t2)
+
+		if t1 != t2 && !t2.Implements(t1) {
+			return fmt.Errorf("Param n°%d should be `%s` not `%s`", i+1, t1, t2)
 		}
 	}
 

--- a/job_test.go
+++ b/job_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/mileusna/crontab"
+	test "github.com/mileusna/crontab_test"
 )
 
 func TestJobError(t *testing.T) {
@@ -47,7 +48,7 @@ func TestCrontab(t *testing.T) {
 	testN = 0
 	testS = ""
 
-	ctab := crontab.Fake(2) // fake crontab wiht 2sec timer to speed up test
+	ctab := test.Fake(2) // fake crontab wiht 2sec timer to speed up test
 
 	var wg sync.WaitGroup
 	wg.Add(2)


### PR DESCRIPTION
Suppose you schedule a function that expects some interface type T as one of its arguments.
Then this change allows to use a concrete type C in place of T, provided that C implements T.
Also, a minor correction is done in `job_test.go`.