### PR TITLE
Add use of interfaces in function args

### DIFF
--- a/crontab.go
+++ b/crontab.go
@@ -86,8 +86,9 @@ func (c *Crontab) AddJob(schedule string, fn interface{}, args ...interface{}) e
 		a := args[i]
 		t1 := fnType.In(i)
 		t2 := reflect.TypeOf(a)
-		if t1 != t2 {
-			return fmt.Errorf("Param with index %d shold be `%s` not `%s`", i, t1, t2)
+
+		if t1 != t2 && !t2.Implements(t1) {
+			return fmt.Errorf("Param n°%d should be `%s` not `%s`", i+1, t1, t2)
 		}
 	}
 


### PR DESCRIPTION
Allows to  a function that uses types that are interfaces T1, T2, etc, and then pass this function to the scheduler, with concrete types C1, C2, etc, provided that C1 implements T1, C2 implements T2, etc.