### PR TITLE
Add named jobs

### DIFF
--- a/crontab.go
+++ b/crontab.go
@@ -333,3 +333,11 @@ func getTick(t time.Time) tick {
 		dayOfWeek: int(t.Weekday()),
 	}
 }
+
+// GetFn returns the function associated with a job retrieved with its name
+func (c *Crontab) GetFn(name string) interface{} {
+	if j, ok := c.jobs[name]; ok {
+		return j.fn
+	}
+	return nil
+}


### PR DESCRIPTION
Associates a job with a name, opening the possibility to later refer to a particular job, to be able to stop it (remove it from the crontab), or run it on demand. 