### PR TITLE
Add SetLocation method to crontab

### DIFF
--- a/crontab.go
+++ b/crontab.go
@@ -17,6 +17,7 @@ type Crontab struct {
 	ticker *time.Ticker
 	jobs   []*job
 	sync.RWMutex
+	location *time.Location
 }
 
 // job in cron table
@@ -60,6 +61,13 @@ func new(t time.Duration) *Crontab {
 	}()
 
 	return c
+}
+
+// SetLocation to run cron on specific timezone.
+//
+// Returns error if provided location is not valid
+func (c *Crontab) SetLocation(loc *time.Location) {
+	c.location = loc
 }
 
 // AddJob to cron table
@@ -153,6 +161,10 @@ func (c *Crontab) RunAll() {
 
 // RunScheduled jobs
 func (c *Crontab) runScheduled(t time.Time) {
+	if c.location != nil {
+		t = t.In(c.location)
+	}
+
 	tick := getTick(t)
 	c.RLock()
 	defer c.RUnlock()

--- a/crontab_test.go
+++ b/crontab_test.go
@@ -1,7 +1,9 @@
 package crontab
 
-import "testing"
-import "time"
+import (
+	"testing"
+	"time"
+)
 
 // TestSchedule parse the crontab syntax and compare number of target min/hour/days/month with expected ones
 func TestSchedule(t *testing.T) {


### PR DESCRIPTION
This method allow us to run cron on specific time zone. location can be set after initiating crontab.

```
ctab := crontab.New()
err := ctab.SetLocation("Asia/Jakarta")
if err != nil {
	return err
}
```